### PR TITLE
bug fix: Graph does not appear in the case of 0 (for IE8)

### DIFF
--- a/js/visualize.jQuery.js
+++ b/js/visualize.jQuery.js
@@ -193,16 +193,18 @@ $.fn.visualize = function(options, container){
 				//draw the pie pieces
 				$.each(memberTotals, function(i){
 					var fraction = (this <= 0 || isNaN(this))? 0 : this / dataSum;
-					ctx.beginPath();
-					ctx.moveTo(centerx, centery);
-					ctx.arc(centerx, centery, radius, 
-						counter * Math.PI * 2 - Math.PI * 0.5,
-						(counter + fraction) * Math.PI * 2 - Math.PI * 0.5,
-		                false);
-			        ctx.lineTo(centerx, centery);
-			        ctx.closePath();
-			        ctx.fillStyle = dataGroups[i].color;
-			        ctx.fill();
+					if(fraction > 0){
+						ctx.beginPath();
+						ctx.moveTo(centerx, centery);
+						ctx.arc(centerx, centery, radius, 
+							counter * Math.PI * 2 - Math.PI * 0.5,
+							(counter + fraction) * Math.PI * 2 - Math.PI * 0.5,
+							false);
+						ctx.lineTo(centerx, centery);
+						ctx.closePath();
+						ctx.fillStyle = dataGroups[i].color;
+						ctx.fill();
+					}
 			        // draw labels
 			       	var sliceMiddle = (counter + fraction/2);
 			       	var distance = o.pieLabelPos == 'inside' ? radius/1.5 : radius +  radius / 5;
@@ -369,7 +371,10 @@ $.fn.visualize = function(options, container){
 						xVal += o.barGroupMargin*2;
 						
 						ctx.moveTo(xVal, 0);
-						ctx.lineTo(xVal, Math.round(-points[i]*yScale));
+						var yVal = Math.round(-points[i]*yScale);
+						if(yVal < 0){
+							ctx.lineTo(xVal, yVal);
+						}
 						integer+=xInterval;
 					}
 					ctx.strokeStyle = dataGroups[h].color;


### PR DESCRIPTION
Bar chart and pie chart does not appear that the value is zero and the last in the case of IE8.

Screen shot of this problem, please refer to the following URL:
https://docs.google.com/folder/d/0B0_wF0RgGqqjdmN3VEgzSW5saE0/edit
